### PR TITLE
Fixes CSS issues. Moves Spotify details to bottom panel.

### DIFF
--- a/lib/atomify-view.js
+++ b/lib/atomify-view.js
@@ -52,22 +52,21 @@ export default class AtomifyView {
   drawElement() {
     this.element = document.createElement('div');
     this.element.id = 'atomify';
-    this.element.className = 'inline-block';
 
-    let spotifySettings = document.createElement('span');
+    let spotifySettings = document.createElement('div');
     spotifySettings.id = 'spotify-settings-details';
-    spotifySettings.className = 'inline-block';
+    spotifySettings.className = 'spotify-settings-details';
     this.element.appendChild(spotifySettings);
 
-    let spotifyMusicDetails = document.createElement('marquee');
+    let spotifyMusicDetails = document.createElement('div');
     spotifyMusicDetails.id = 'spotify-music-details';
     spotifyMusicDetails.className = 'spotify-music-details';
     this.element.appendChild(spotifyMusicDetails);
 
-    this.statusBar.addRightTile({
+    atom.workspace.addBottomPanel({
       item: this.element,
-      priority: -10
-    })
+      priority: 100
+    });
   }
 
   // Tear down any state and detach

--- a/lib/services/DisplayBuilder.js
+++ b/lib/services/DisplayBuilder.js
@@ -28,11 +28,11 @@ export default class DisplayBuilder {
   static getPlayerStateImageUrl(state) {
     switch (state) {
       case PlayerState.PLAYING: {
-        return 'https://raw.githubusercontent.com/jaebradley/atomify/master/images/play.png?raw=true';
+        return DisplayBuilder.getPlayIconUrl();
       }
 
       default: {
-        return 'https://raw.githubusercontent.com/jaebradley/atomify/master/images/pause.png?raw=true';
+        return DisplayBuilder.getPauseIconUrl();
       }
     }
   }
@@ -56,6 +56,14 @@ export default class DisplayBuilder {
 
   static buildIcon(source) {
     return `<img class="atomify-icon" src='${source}' />`;
+  }
+
+  static getPauseIconUrl() {
+    return 'https://raw.githubusercontent.com/jaebradley/atomify/master/images/pause.png?raw=true';
+  }
+
+  static getPlayIconUrl() {
+    return 'https://raw.githubusercontent.com/jaebradley/atomify/master/images/play.png?raw=true';
   }
 
   static getShuffleIconUrl() {

--- a/lib/services/DisplayBuilder.js
+++ b/lib/services/DisplayBuilder.js
@@ -3,14 +3,13 @@
 import PlayerState from '../data/PlayerState';
 
 export default class DisplayBuilder {
-
   static buildInactiveSettingsDetails() {
     const spotifyIconUrl = 'https://raw.githubusercontent.com/jaebradley/atomify/master/images/spotify.png?raw=true';
-    return `<img src=${spotifyIconUrl} style="margin-right:5px" /> Not Open`;
+    return `<img class="atomify-icon" src=${spotifyIconUrl} /> Not Open`;
   }
 
   static buildMusicDetails(spotifyStateDetails){
-    return `${spotifyStateDetails.song} | ${spotifyStateDetails.artist} | ${spotifyStateDetails.album} (${spotifyStateDetails.songPosition} / ${spotifyStateDetails.songDuration})`;
+    return `${spotifyStateDetails.song} | ${spotifyStateDetails.artist} | ${spotifyStateDetails.album} ( ${spotifyStateDetails.songPosition} / ${spotifyStateDetails.songDuration} )`;
   }
 
   static buildSettingsDetails(spotifyStateDetails) {
@@ -18,7 +17,7 @@ export default class DisplayBuilder {
     const playerStateImageUrl = DisplayBuilder.getPlayerStateImageUrl(spotifyStateDetails.playerState);
     const playerSettingImages = DisplayBuilder.getPlayerSettingImages(spotifyStateDetails.isShuffling, spotifyStateDetails.isRepeating);
 
-    const defaultSettings = `<img src=${spotifyIconUrl} style="margin-right:5px" /> <img src=${playerStateImageUrl} style="margin-right:5px" />`;
+    const defaultSettings = `<img class="atomify-icon" src=${spotifyIconUrl} /> <img class="atomify-icon" src=${playerStateImageUrl} />`;
     if (playerSettingImages == undefined) {
       return defaultSettings;
     }
@@ -45,13 +44,25 @@ export default class DisplayBuilder {
 
     let images = '';
     if (isShuffling) {
-      images += `<img src='https://raw.githubusercontent.com/jaebradley/atomify/master/images/shuffle.png?raw=true' style="margin-right:5px" />`;
+      images += DisplayBuilder.buildIcon(DisplayBuilder.getShuffleIconUrl());
     }
 
     if (isRepeating) {
-      images += `<img src='https://raw.githubusercontent.com/jaebradley/atomify/master/images/repeat.png?raw=true' style="margin-right:5px" />`;
+      images += DisplayBuilder.buildIcon(DisplayBuilder.getRepeatIconUrl());
     }
 
     return images;
+  }
+
+  static buildIcon(source) {
+    return `<img class="atomify-icon" src='${source}' />`;
+  }
+
+  static getShuffleIconUrl() {
+    return 'https://raw.githubusercontent.com/jaebradley/atomify/master/images/shuffle.png?raw=true';
+  }
+
+  static getRepeatIconUrl() {
+    return 'https://raw.githubusercontent.com/jaebradley/atomify/master/images/repeat.png?raw=true';
   }
 }

--- a/lib/services/DisplayBuilder.js
+++ b/lib/services/DisplayBuilder.js
@@ -4,8 +4,7 @@ import PlayerState from '../data/PlayerState';
 
 export default class DisplayBuilder {
   static buildInactiveSettingsDetails() {
-    const spotifyIconUrl = 'https://raw.githubusercontent.com/jaebradley/atomify/master/images/spotify.png?raw=true';
-    return `<img class="atomify-icon" src=${spotifyIconUrl} /> Not Open`;
+    return `${DisplayBuilder.buildIcon(DisplayBuilder.getSpotifyIconUrl())} Not Open`;
   }
 
   static buildMusicDetails(spotifyStateDetails){
@@ -13,11 +12,13 @@ export default class DisplayBuilder {
   }
 
   static buildSettingsDetails(spotifyStateDetails) {
-    const spotifyIconUrl = 'https://raw.githubusercontent.com/jaebradley/atomify/master/images/spotify.png?raw=true';
     const playerStateImageUrl = DisplayBuilder.getPlayerStateImageUrl(spotifyStateDetails.playerState);
     const playerSettingImages = DisplayBuilder.getPlayerSettingImages(spotifyStateDetails.isShuffling, spotifyStateDetails.isRepeating);
+    const spotifyIcon = DisplayBuilder.buildIcon(DisplayBuilder.getSpotifyIconUrl())
+    const playerStateIcon = DisplayBuilder.buildIcon(playerStateImageUrl);
 
-    const defaultSettings = `<img class="atomify-icon" src=${spotifyIconUrl} /> <img class="atomify-icon" src=${playerStateImageUrl} />`;
+    const defaultSettings = `${spotifyIcon} ${playerStateIcon}`;
+
     if (playerSettingImages == undefined) {
       return defaultSettings;
     }
@@ -56,6 +57,10 @@ export default class DisplayBuilder {
 
   static buildIcon(source) {
     return `<img class="atomify-icon" src='${source}' />`;
+  }
+
+  static getSpotifyIconUrl() {
+    return 'https://raw.githubusercontent.com/jaebradley/atomify/master/images/spotify.png?raw=true';
   }
 
   static getPauseIconUrl() {

--- a/styles/atomify.less
+++ b/styles/atomify.less
@@ -1,8 +1,17 @@
-// The ui-variables file is provided by base themes provided by Atom.
-//
-// See https://github.com/atom/atom-dark-ui/blob/master/styles/ui-variables.less
-// for a full listing of what's available.
 @import "ui-variables";
 
-.atomify {
+#atomify {
+  margin-top: 5px;
+}
+
+.spotify-settings-details {
+  display: inline-block;
+}
+
+.spotify-music-details {
+  display: inline-block;
+}
+
+.atomify-icon {
+  margin-right: 10px;
 }


### PR DESCRIPTION
@lefoy

Hopefully resolves #14. 

Also moves Spotify details from status bar to bottom panel. Prefer this to atomify in status bar? Reasoning is that on smaller screens / with a lot of packages populating the status bar Spotify details are not seen.

![image](https://cloud.githubusercontent.com/assets/8136030/23045318/3ab175d6-f472-11e6-8243-b2ad67f4fc4e.png)
